### PR TITLE
Update expandvars.py

### DIFF
--- a/expandvars.py
+++ b/expandvars.py
@@ -392,7 +392,7 @@ def expand_default(var, vars_, set_, nounset, indirect, environ, var_symbol):
     for c in vars_:
         if c == "}":
             n = len(default) + 1
-            default_ = "".join(default)
+            default_ = expand("".join(default))
             if set_ and var not in environ:
                 environ.update({var: default_})
             return getenv(

--- a/tests/test_expandvars.py
+++ b/tests/test_expandvars.py
@@ -62,7 +62,7 @@ def test_expandvars_pid():
     assert expandvars.expandvars("PID( $$ )") == "PID( {0} )".format(getpid())
 
 
-@patch.dict(env, {})
+@patch.dict(env, {"ALTERNATE": "Alternate"})
 def test_expandvars_get_default():
     importlib.reload(expandvars)
 
@@ -70,6 +70,7 @@ def test_expandvars_get_default():
     assert expandvars.expandvars("${FOO:-default}") == "default"
     assert expandvars.expandvars("${FOO:-}") == ""
     assert expandvars.expandvars("${FOO:-foo}:${FOO-bar}") == "foo:bar"
+    assert expandvars.expandvars("${FOO:-$ALTERNATE}") == "Alternate"
 
 
 @patch.dict(env, {})


### PR DESCRIPTION
Fixes #40 
Do check this as it's getting into recursive territory and I only did some basic local testing

```python
import os
import expandvars

os.environ['VAR1'] = '1'
os.environ['VAR2'] = '2'

v = '${VAR1:-$VAR2}'
print(f'{v} expands to "{expandvars(v)}"')

v = '${VAR3:-$VAR2}'
print(f'{v} expands to "{expandvars(v)}"')

v = '${VAR3:-//Some/sort/of/path}'
print(f'{v} expands to "{expandvars(v)}"')
```

Produces
```
${VAR1:-$VAR2} expands to "1"
${VAR3:-$VAR2} expands to "2"
${VAR3:-//Some/sort/of/path} expands to "//Some/sort/of/path"
```