### PR TITLE
Added installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ my_nested_variable = "${!NESTED}"
 > it doesn't follow bash strictly. For example, it doesn't work with arrays.
 
 
+Installation
+------------
+
+### Pip
+```
+pip install expandvars
+```
+
+### Conda
+```
+conda install -c conda-forge expandvars
+```
+
 Usage
 -----
 


### PR DESCRIPTION
Since `expandvars` is now available on both PyPI and conda forge, it might be a good idea to document the different installation options in the README.
This pull request addresses this and resolves #55.