### PR TITLE
Add `build-system` to `pyproject.toml` to make the package buildable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = 'expandvars'
 version = '0.11.0'


### PR DESCRIPTION
Add missing `build-system` section to make it possible to actually build the package via the PEP517 backend.  Otherwise, implicit setuptools fallback is used and an empty package is built that is afterwards rejected:

```
$ pip install --no-binary expandvars expandvars
Collecting expandvars
  Downloading expandvars-0.11.0.tar.gz (5.9 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Discarding https://files.pythonhosted.org/packages/74/55/7531be1d92ad1a2b1eb59ceaf7871e878db76b55409e68d6e07663a096d2/expandvars-0.11.0.tar.gz (from https://pypi.org/simple/expandvars/) (requires-python:>=3.6): Requested expandvars from https://files.pythonhosted.org/packages/74/55/7531be1d92ad1a2b1eb59ceaf7871e878db76b55409e68d6e07663a096d2/expandvars-0.11.0.tar.gz has inconsistent version: expected '0.11.0', but metadata has '0.0.0'
```