### PR TITLE
fix: add ability to disable escape and force ${var} usage.

### DIFF
--- a/expandvars.py
+++ b/expandvars.py
@@ -107,8 +107,8 @@ def expand(
     nounset=False,
     environ=os.environ,
     var_symbol="$",
-    var_symbol_require_suffix=False,
-    disable_escape=False,
+    surrounded_vars_only=False,
+    escape_char=ESCAPE_CHAR,
 ):
     """Expand variables Unix style.
 
@@ -144,9 +144,9 @@ def expand(
     vars_iter = _PeekableIterator(vars_)
     try:
         for c in vars_iter:
-            if not disable_escape and c == ESCAPE_CHAR:
+            if escape_char and c == escape_char:
                 next_ = vars_iter.peek()
-                if next_ == var_symbol or next_ == ESCAPE_CHAR:
+                if next_ == var_symbol or next_ == escape_char:
                     buff.append(next(vars_iter))
                 elif next_ == _PeekableIterator.NOTHING:
                     raise MissingEscapedChar(c)
@@ -157,7 +157,7 @@ def expand(
                 next_ = vars_iter.peek()
                 if next_ == _PeekableIterator.NOTHING:
                     buff.append(c)
-                elif var_symbol_require_suffix and next_ != "{":
+                elif surrounded_vars_only and next_ != "{":
                     buff.append(c)
                 elif _valid_char(next_) or next_ == "{" or next_ == var_symbol:
                     val = _expand_var(

--- a/expandvars.py
+++ b/expandvars.py
@@ -102,7 +102,14 @@ def getenv(var, indirect, environ, var_symbol="$"):
     return val
 
 
-def expand(vars_, nounset=False, environ=os.environ, var_symbol="$"):
+def expand(
+    vars_,
+    nounset=False,
+    environ=os.environ,
+    var_symbol="$",
+    var_symbol_require_suffix=False,
+    disable_escape=False,
+):
     """Expand variables Unix style.
 
     Params:
@@ -137,7 +144,7 @@ def expand(vars_, nounset=False, environ=os.environ, var_symbol="$"):
     vars_iter = _PeekableIterator(vars_)
     try:
         for c in vars_iter:
-            if c == ESCAPE_CHAR:
+            if not disable_escape and c == ESCAPE_CHAR:
                 next_ = vars_iter.peek()
                 if next_ == var_symbol or next_ == ESCAPE_CHAR:
                     buff.append(next(vars_iter))
@@ -149,6 +156,8 @@ def expand(vars_, nounset=False, environ=os.environ, var_symbol="$"):
             elif c == var_symbol:
                 next_ = vars_iter.peek()
                 if next_ == _PeekableIterator.NOTHING:
+                    buff.append(c)
+                elif var_symbol_require_suffix and next_ != "{":
                     buff.append(c)
                 elif _valid_char(next_) or next_ == "{" or next_ == var_symbol:
                     val = _expand_var(

--- a/tests/test_expandvars.py
+++ b/tests/test_expandvars.py
@@ -400,15 +400,13 @@ def test_expand_var_symbol(var_symbol):
 def test_expandvars_require_suffix():
     importlib.reload(expandvars)
 
-    assert (
-        expandvars.expand("${FOO}:$BIZ", var_symbol_require_suffix=True) == "bar:$BIZ"
-    )
-    assert expandvars.expand("$FOO$BIZ", var_symbol_require_suffix=True) == "$FOO$BIZ"
-    assert expandvars.expand("${FOO}$BIZ", var_symbol_require_suffix=True) == "bar$BIZ"
-    assert expandvars.expand("$FOO${BIZ}", var_symbol_require_suffix=True) == "$FOObuz"
-    assert expandvars.expand("$FOO-$BIZ", var_symbol_require_suffix=True) == "$FOO-$BIZ"
-    assert expandvars.expand("boo$BIZ", var_symbol_require_suffix=True) == "boo$BIZ"
-    assert expandvars.expand("boo${BIZ}", var_symbol_require_suffix=True) == "boobuz"
+    assert expandvars.expand("${FOO}:$BIZ", surrounded_vars_only=True) == "bar:$BIZ"
+    assert expandvars.expand("$FOO$BIZ", surrounded_vars_only=True) == "$FOO$BIZ"
+    assert expandvars.expand("${FOO}$BIZ", surrounded_vars_only=True) == "bar$BIZ"
+    assert expandvars.expand("$FOO${BIZ}", surrounded_vars_only=True) == "$FOObuz"
+    assert expandvars.expand("$FOO-$BIZ", surrounded_vars_only=True) == "$FOO-$BIZ"
+    assert expandvars.expand("boo$BIZ", surrounded_vars_only=True) == "boo$BIZ"
+    assert expandvars.expand("boo${BIZ}", surrounded_vars_only=True) == "boobuz"
 
 
 @patch.dict(env, {"FOO": "bar", "BIZ": "buz"}, clear=True)
@@ -416,8 +414,6 @@ def test_expandvars_disable_escape():
     importlib.reload(expandvars)
 
     assert (
-        expandvars.expand(
-            "\\foo\\", var_symbol_require_suffix=True, disable_escape=True
-        )
+        expandvars.expand("\\foo\\", surrounded_vars_only=True, escape_char=None)
         == "\\foo\\"
     )

--- a/tests/test_expandvars.py
+++ b/tests/test_expandvars.py
@@ -394,3 +394,30 @@ def test_expand_var_symbol(var_symbol):
         )
         == "test,$HOME"
     )
+
+
+@patch.dict(env, {"FOO": "bar", "BIZ": "buz"}, clear=True)
+def test_expandvars_require_suffix():
+    importlib.reload(expandvars)
+
+    assert (
+        expandvars.expand("${FOO}:$BIZ", var_symbol_require_suffix=True) == "bar:$BIZ"
+    )
+    assert expandvars.expand("$FOO$BIZ", var_symbol_require_suffix=True) == "$FOO$BIZ"
+    assert expandvars.expand("${FOO}$BIZ", var_symbol_require_suffix=True) == "bar$BIZ"
+    assert expandvars.expand("$FOO${BIZ}", var_symbol_require_suffix=True) == "$FOObuz"
+    assert expandvars.expand("$FOO-$BIZ", var_symbol_require_suffix=True) == "$FOO-$BIZ"
+    assert expandvars.expand("boo$BIZ", var_symbol_require_suffix=True) == "boo$BIZ"
+    assert expandvars.expand("boo${BIZ}", var_symbol_require_suffix=True) == "boobuz"
+
+
+@patch.dict(env, {"FOO": "bar", "BIZ": "buz"}, clear=True)
+def test_expandvars_disable_escape():
+    importlib.reload(expandvars)
+
+    assert (
+        expandvars.expand(
+            "\\foo\\", var_symbol_require_suffix=True, disable_escape=True
+        )
+        == "\\foo\\"
+    )


### PR DESCRIPTION
In order to support expands vars in a windows environment, where paths may exist, as:

\foo\bar\

The \ should not be the escape char.

Related, add a strictness for the var symbol, requiring ${}. This is optional, but useful to further qualify when a var should be interpreted.