### PR TITLE
Fix configuration for pytest 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,4 @@ build-backend = "hatchling.build"
 path = "expandvars.py"
 
 [tool.pytest]
-addopts = '--cov --cov-report=html --cov-fail-under=100'
+addopts = ["--cov", "--cov-report=html", "--cov-fail-under=100"]


### PR DESCRIPTION
Before this change, pytest 9 failed with:

```
TypeError: pyproject.toml: config option 'addopts' expects a list for type 'args', got str: '--cov --cov-report=html --cov-fail-under=100'
```

See https://github.com/pytest-dev/pytest/issues/13743.